### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,4 +1,6 @@
 name: Linters
+permissions:
+  contents: read
 on:
   push:
 


### PR DESCRIPTION
Potential fix for [https://github.com/Rupreht/SmartBookingAgent/security/code-scanning/1](https://github.com/Rupreht/SmartBookingAgent/security/code-scanning/1)

To fix the problem, we should add a `permissions` block to the workflow to restrict the permissions of the GITHUB_TOKEN to the minimum required. Since the workflow only checks out code and runs linters, it does not need write access to repository contents or other resources. The minimal required permission is `contents: read`. This block can be added either at the root of the workflow (to apply to all jobs) or at the job level. The best practice is to add it at the root level, just below the `name` and before the `on` key, so it applies to all jobs unless overridden. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
